### PR TITLE
docs: update readme to include bibtex entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# PCAx: Minimal Principal Component Analysis in Jax.
+# pcax
 
+**PCAx** is a minimal Principal Component Analysis (PCA) written in Jax.
 The aim of this project is to provide a JAX-based PCA implementation, eliminating the need for unnecessary data transfer to CPU or conversions to Numpy. This can provide performance benefits when working with large datasets or in GPU-intensive workflow
 
 ## Usage
@@ -22,8 +23,13 @@ X_recover = pcax.recover(state, X_pca)
 pip install pcax
 ```
 
-Alternatively, it can be installed directly from the GitHub repository:
+## Citation
+If you use `pcax` in your research and need to reference it, please cite it as follows:
 ```
-pip install git+git://github.com/alonfnt/pcax.git
+@software{alonso_pcax,
+  author = {Alonso, Albert},
+  title = {pcax: Minimal Principal Component Analysis (PCA) Implementation in JAX},
+  url = {https://github.com/alonfnt/pcax},
+  version = {0.0.1}
+}
 ```
-


### PR DESCRIPTION
It is common for research projects to use software such as pcax, and some journals require authors to cite the libraries they use.  Now pcax has a quick citation entry to ease the process.